### PR TITLE
fix: change cache save/restore action to v5

### DIFF
--- a/ffmpeg/action.yaml
+++ b/ffmpeg/action.yaml
@@ -29,7 +29,7 @@ runs:
         
     - name: Restore yt-dlp/FFmpeg-Builds cache
       id: cache
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: ${{ runner.tool_cache }}/yt-dlp-FFmpeg
         key: yt-dlp-FFmpeg-${{ steps.release-id-linux.outputs.release_id || steps.release-id-windows.outputs.release_id }}-${{ runner.os }}
@@ -54,7 +54,7 @@ runs:
         
     - name: Save yt-dlp/FFmpeg-Builds cache
       if: '! steps.cache.outputs.cache-hit'
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v5
       with:
         path: ${{ runner.tool_cache }}/yt-dlp-FFmpeg
         key: yt-dlp-FFmpeg-${{ steps.release-id-linux.outputs.release_id || steps.release-id-windows.outputs.release_id }}-${{ runner.os }}


### PR DESCRIPTION
to fix `Node.js 20 actions are deprecated` warning

Warning: Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/cache/restore@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
